### PR TITLE
refactor(api): Add PostgreSQL-backed road segment model and alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ docs/_build/
 examples/**/*.json
 !examples/**/package.json
 !examples/**/package-lock.json
+!examples/road_inspection/api/road_segments.json
 
 
 # Exception

--- a/examples/road_inspection/api/__init__.py
+++ b/examples/road_inspection/api/__init__.py
@@ -1,0 +1,7 @@
+"""Road inspection API module.
+
+This package contains an example FastAPI application for managing road
+segment inspection data. It demonstrates how to integrate a PostgreSQL
+backend with a JSON fallback when the database is unavailable.
+"""
+

--- a/examples/road_inspection/api/crud.py
+++ b/examples/road_inspection/api/crud.py
@@ -1,0 +1,131 @@
+import json
+import uuid
+from typing import List, Optional
+from sqlalchemy.orm import Session
+
+from .database import USE_DB, JSON_DATA_FILE
+from .models import RoadSegment, Priority, RoadStatus
+from .schemas import RoadSegmentCreate, RoadSegmentUpdate
+
+
+def _compute_priority_and_status(index: int, status: Optional[RoadStatus]) -> tuple[Priority, RoadStatus]:
+    if index < 50:
+        return Priority.HIGH, RoadStatus.NEEDS_REPAIR
+    if index < 75:
+        return Priority.MEDIUM, status or RoadStatus.ACTIVE
+    return Priority.LOW, status or RoadStatus.ACTIVE
+
+
+# JSON fallback helpers
+
+def _load_json() -> List[dict]:
+    with open(JSON_DATA_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_json(data: List[dict]) -> None:
+    with open(JSON_DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, default=str)
+
+
+# CRUD operations
+
+def get_segments(db: Session) -> List[RoadSegment]:
+    if USE_DB:
+        return db.query(RoadSegment).all()
+    return [RoadSegment(**item) for item in _load_json()]
+
+
+def get_segment(db: Session, segment_id: str) -> Optional[RoadSegment]:
+    if USE_DB:
+        return db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
+    items = _load_json()
+    for item in items:
+        if item["id"] == segment_id:
+            return RoadSegment(**item)
+    return None
+
+
+def create_segment(db: Session, segment: RoadSegmentCreate) -> RoadSegment:
+    priority, status = _compute_priority_and_status(segment.road_condition_index, segment.status)
+    if USE_DB:
+        db_obj = RoadSegment(
+            id=uuid.uuid4(),
+            name=segment.name,
+            geometry=segment.geometry,
+            road_condition_index=segment.road_condition_index,
+            damage_types=segment.damage_types,
+            last_inspection=segment.last_inspection,
+            priority=priority,
+            status=status,
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    items = _load_json()
+    db_obj = {
+        "id": str(uuid.uuid4()),
+        "name": segment.name,
+        "geometry": segment.geometry,
+        "road_condition_index": segment.road_condition_index,
+        "damage_types": segment.damage_types,
+        "last_inspection": segment.last_inspection.isoformat() if segment.last_inspection else None,
+        "priority": priority.value,
+        "status": status.value,
+    }
+    items.append(db_obj)
+    _write_json(items)
+    return RoadSegment(**db_obj)
+
+
+def update_segment(db: Session, segment_id: str, updates: RoadSegmentUpdate) -> Optional[RoadSegment]:
+    if USE_DB:
+        db_obj = db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
+        if not db_obj:
+            return None
+        for field, value in updates.model_dump(exclude_unset=True).items():
+            setattr(db_obj, field, value)
+        if updates.road_condition_index is not None:
+            db_obj.priority, db_obj.status = _compute_priority_and_status(updates.road_condition_index, updates.status or db_obj.status)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    items = _load_json()
+    for item in items:
+        if item["id"] == segment_id:
+            data = updates.model_dump(exclude_unset=True)
+            item.update(data)
+            index = item.get("road_condition_index")
+            if index is not None:
+                prio, stat = _compute_priority_and_status(index, RoadStatus(item.get("status", "Active")))
+                item["priority"] = prio.value
+                item["status"] = stat.value
+            _write_json(items)
+            return RoadSegment(**item)
+    return None
+
+
+def delete_segment(db: Session, segment_id: str) -> bool:
+    if USE_DB:
+        obj = db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
+        if not obj:
+            return False
+        db.delete(obj)
+        db.commit()
+        return True
+
+    items = _load_json()
+    new_items = [item for item in items if item["id"] != segment_id]
+    if len(new_items) == len(items):
+        return False
+    _write_json(new_items)
+    return True
+
+
+def alert_segments(db: Session) -> List[RoadSegment]:
+    if USE_DB:
+        return db.query(RoadSegment).filter(RoadSegment.priority == Priority.HIGH).all()
+    return [RoadSegment(**item) for item in _load_json() if item.get("priority") == Priority.HIGH.value]

--- a/examples/road_inspection/api/crud.py
+++ b/examples/road_inspection/api/crud.py
@@ -1,3 +1,5 @@
+"""CRUD helpers for the road inspection API."""
+
 import json
 import uuid
 from typing import List, Optional
@@ -9,6 +11,8 @@ from .schemas import RoadSegmentCreate, RoadSegmentUpdate
 
 
 def _compute_priority_and_status(index: int, status: Optional[RoadStatus]) -> tuple[Priority, RoadStatus]:
+    """Derive priority and status values based on the condition index."""
+
     if index < 50:
         return Priority.HIGH, RoadStatus.NEEDS_REPAIR
     if index < 75:
@@ -19,11 +23,15 @@ def _compute_priority_and_status(index: int, status: Optional[RoadStatus]) -> tu
 # JSON fallback helpers
 
 def _load_json() -> List[dict]:
+    """Load road segment records from the JSON fallback file."""
+
     with open(JSON_DATA_FILE, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def _write_json(data: List[dict]) -> None:
+    """Persist road segment records to the JSON fallback file."""
+
     with open(JSON_DATA_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, default=str)
 
@@ -31,14 +39,19 @@ def _write_json(data: List[dict]) -> None:
 # CRUD operations
 
 def get_segments(db: Session) -> List[RoadSegment]:
+    """Return all known road segments."""
+
     if USE_DB:
         return db.query(RoadSegment).all()
     return [RoadSegment(**item) for item in _load_json()]
 
 
 def get_segment(db: Session, segment_id: str) -> Optional[RoadSegment]:
+    """Retrieve a single segment by its identifier."""
+
     if USE_DB:
         return db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
+
     items = _load_json()
     for item in items:
         if item["id"] == segment_id:
@@ -47,7 +60,10 @@ def get_segment(db: Session, segment_id: str) -> Optional[RoadSegment]:
 
 
 def create_segment(db: Session, segment: RoadSegmentCreate) -> RoadSegment:
+    """Insert a new road segment record."""
+
     priority, status = _compute_priority_and_status(segment.road_condition_index, segment.status)
+
     if USE_DB:
         db_obj = RoadSegment(
             id=uuid.uuid4(),
@@ -81,14 +97,21 @@ def create_segment(db: Session, segment: RoadSegmentCreate) -> RoadSegment:
 
 
 def update_segment(db: Session, segment_id: str, updates: RoadSegmentUpdate) -> Optional[RoadSegment]:
+    """Modify an existing segment."""
+
     if USE_DB:
         db_obj = db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
         if not db_obj:
             return None
+
         for field, value in updates.model_dump(exclude_unset=True).items():
             setattr(db_obj, field, value)
+
         if updates.road_condition_index is not None:
-            db_obj.priority, db_obj.status = _compute_priority_and_status(updates.road_condition_index, updates.status or db_obj.status)
+            db_obj.priority, db_obj.status = _compute_priority_and_status(
+                updates.road_condition_index, updates.status or db_obj.status
+            )
+
         db.commit()
         db.refresh(db_obj)
         return db_obj
@@ -105,10 +128,13 @@ def update_segment(db: Session, segment_id: str, updates: RoadSegmentUpdate) -> 
                 item["status"] = stat.value
             _write_json(items)
             return RoadSegment(**item)
+
     return None
 
 
 def delete_segment(db: Session, segment_id: str) -> bool:
+    """Remove a segment from storage."""
+
     if USE_DB:
         obj = db.query(RoadSegment).filter(RoadSegment.id == segment_id).first()
         if not obj:
@@ -126,6 +152,9 @@ def delete_segment(db: Session, segment_id: str) -> bool:
 
 
 def alert_segments(db: Session) -> List[RoadSegment]:
+    """Return segments flagged as high priority."""
+
     if USE_DB:
         return db.query(RoadSegment).filter(RoadSegment.priority == Priority.HIGH).all()
+
     return [RoadSegment(**item) for item in _load_json() if item.get("priority") == Priority.HIGH.value]

--- a/examples/road_inspection/api/database.py
+++ b/examples/road_inspection/api/database.py
@@ -1,17 +1,35 @@
+"""Database utilities for the road inspection API."""
+
 import os
 import json
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, declarative_base
 
+# Connection string for PostgreSQL database.  This value comes from the
+# environment so that this example can be easily configured without
+# hardcoding credentials.
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+# Flag indicating whether the database should be used.  If the connection
+# fails for any reason we fall back to JSON storage and this flag is set to
+# ``False``.
 USE_DB = True
+
+# Global SQLAlchemy objects; these are initialised only when a connection is
+# successfully established.
 engine = None
 SessionLocal = None
 Base = declarative_base()
 
+# Attempt to create a database engine if a connection string has been
+# provided.  This is wrapped in a ``try`` block so that if the database is not
+# yet available (for example during local development) the application will
+# gracefully degrade to using a JSON file for persistence.
 if DATABASE_URL:
     try:
         engine = create_engine(DATABASE_URL)
+        # Simple connectivity check so we can fall back to JSON if the DB is
+        # unreachable.
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
         SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -20,15 +38,25 @@ if DATABASE_URL:
 else:
     USE_DB = False
 
+# Location of the JSON file used when the database is not reachable.
 JSON_DATA_FILE = os.path.join(os.path.dirname(__file__), "road_segments.json")
 
 if not USE_DB:
+    # Inform the user that the application is operating in offline mode so they
+    # are aware data will not be persisted to a database.
     print("Database not available, falling back to JSON storage.")
 
 
 def get_db():
+    """Provide a database session to path operations.
+
+    When running without a database (``USE_DB`` is ``False``) this yields
+    ``None`` so the CRUD layer knows to operate on the JSON file instead.
+    """
+
     if not USE_DB:
         return None
+
     db = SessionLocal()
     try:
         yield db

--- a/examples/road_inspection/api/database.py
+++ b/examples/road_inspection/api/database.py
@@ -1,0 +1,36 @@
+import os
+import json
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+USE_DB = True
+engine = None
+SessionLocal = None
+Base = declarative_base()
+
+if DATABASE_URL:
+    try:
+        engine = create_engine(DATABASE_URL)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    except Exception:  # pragma: no cover - fallback logic
+        USE_DB = False
+else:
+    USE_DB = False
+
+JSON_DATA_FILE = os.path.join(os.path.dirname(__file__), "road_segments.json")
+
+if not USE_DB:
+    print("Database not available, falling back to JSON storage.")
+
+
+def get_db():
+    if not USE_DB:
+        return None
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/examples/road_inspection/api/main.py
+++ b/examples/road_inspection/api/main.py
@@ -1,3 +1,5 @@
+"""Minimal FastAPI application exposing road segment management APIs."""
+
 from fastapi import FastAPI, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -15,17 +17,22 @@ from .crud import (
 
 app = FastAPI()
 
+# Create database tables on startup when a PostgreSQL database is configured.
 if USE_DB and engine is not None:
     Base.metadata.create_all(bind=engine)
 
 
 @app.get("/road-segments", response_model=list[RoadSegmentOut])
 def list_segments(db: Session = Depends(get_db)):
+    """Return every road segment in storage."""
+
     return get_segments(db)
 
 
 @app.get("/road-segments/{segment_id}", response_model=RoadSegmentOut)
 def get_single_segment(segment_id: str, db: Session = Depends(get_db)):
+    """Fetch a specific road segment by ID."""
+
     segment = get_segment(db, segment_id)
     if not segment:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -34,11 +41,15 @@ def get_single_segment(segment_id: str, db: Session = Depends(get_db)):
 
 @app.post("/road-segments", response_model=RoadSegmentOut, status_code=status.HTTP_201_CREATED)
 def create_new_segment(segment: RoadSegmentCreate, db: Session = Depends(get_db)):
+    """Create a new road segment."""
+
     return create_segment(db, segment)
 
 
 @app.put("/road-segments/{segment_id}", response_model=RoadSegmentOut)
 def update_existing_segment(segment_id: str, updates: RoadSegmentUpdate, db: Session = Depends(get_db)):
+    """Update an existing road segment."""
+
     seg = update_segment(db, segment_id, updates)
     if not seg:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -47,6 +58,8 @@ def update_existing_segment(segment_id: str, updates: RoadSegmentUpdate, db: Ses
 
 @app.delete("/road-segments/{segment_id}", status_code=status.HTTP_204_NO_CONTENT)
 def remove_segment(segment_id: str, db: Session = Depends(get_db)):
+    """Delete a road segment."""
+
     success = delete_segment(db, segment_id)
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -55,4 +68,6 @@ def remove_segment(segment_id: str, db: Session = Depends(get_db)):
 
 @app.get("/road-segments/alerts", response_model=list[RoadSegmentOut])
 def get_alerts(db: Session = Depends(get_db)):
+    """Return only segments with a high priority."""
+
     return alert_segments(db)

--- a/examples/road_inspection/api/main.py
+++ b/examples/road_inspection/api/main.py
@@ -1,0 +1,58 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .database import Base, engine, USE_DB, get_db
+from .models import RoadSegment
+from .schemas import RoadSegmentCreate, RoadSegmentOut, RoadSegmentUpdate
+from .crud import (
+    get_segments,
+    get_segment,
+    create_segment,
+    update_segment,
+    delete_segment,
+    alert_segments,
+)
+
+app = FastAPI()
+
+if USE_DB and engine is not None:
+    Base.metadata.create_all(bind=engine)
+
+
+@app.get("/road-segments", response_model=list[RoadSegmentOut])
+def list_segments(db: Session = Depends(get_db)):
+    return get_segments(db)
+
+
+@app.get("/road-segments/{segment_id}", response_model=RoadSegmentOut)
+def get_single_segment(segment_id: str, db: Session = Depends(get_db)):
+    segment = get_segment(db, segment_id)
+    if not segment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return segment
+
+
+@app.post("/road-segments", response_model=RoadSegmentOut, status_code=status.HTTP_201_CREATED)
+def create_new_segment(segment: RoadSegmentCreate, db: Session = Depends(get_db)):
+    return create_segment(db, segment)
+
+
+@app.put("/road-segments/{segment_id}", response_model=RoadSegmentOut)
+def update_existing_segment(segment_id: str, updates: RoadSegmentUpdate, db: Session = Depends(get_db)):
+    seg = update_segment(db, segment_id, updates)
+    if not seg:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return seg
+
+
+@app.delete("/road-segments/{segment_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_segment(segment_id: str, db: Session = Depends(get_db)):
+    success = delete_segment(db, segment_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return None
+
+
+@app.get("/road-segments/alerts", response_model=list[RoadSegmentOut])
+def get_alerts(db: Session = Depends(get_db)):
+    return alert_segments(db)

--- a/examples/road_inspection/api/models.py
+++ b/examples/road_inspection/api/models.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String, Enum, JSON
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from .database import Base
+
+
+class RoadStatus(str, Enum):
+    ACTIVE = "Active"
+    NEEDS_REPAIR = "Needs Repair"
+    UNDER_REPAIR = "Under Repair"
+    ARCHIVED = "Archived"
+
+
+class Priority(str, Enum):
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
+
+
+class RoadSegment(Base):
+    __tablename__ = "road_segments"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    geometry = Column(String, nullable=False)
+    road_condition_index = Column(Integer, nullable=False)
+    damage_types = Column(JSON, nullable=False, default=list)
+    last_inspection = Column(DateTime, default=datetime.utcnow)
+    priority = Column(Enum(Priority), nullable=False, default=Priority.LOW)
+    status = Column(Enum(RoadStatus), nullable=False, default=RoadStatus.ACTIVE)

--- a/examples/road_inspection/api/models.py
+++ b/examples/road_inspection/api/models.py
@@ -1,12 +1,17 @@
+"""Database models used by the road inspection API."""
+
 from datetime import datetime
+import uuid
+
 from sqlalchemy import Column, DateTime, Integer, String, Enum, JSON
 from sqlalchemy.dialects.postgresql import UUID
-import uuid
 
 from .database import Base
 
 
 class RoadStatus(str, Enum):
+    """Enumerates the possible lifecycle states for a road segment."""
+
     ACTIVE = "Active"
     NEEDS_REPAIR = "Needs Repair"
     UNDER_REPAIR = "Under Repair"
@@ -14,19 +19,42 @@ class RoadStatus(str, Enum):
 
 
 class Priority(str, Enum):
+    """Represents the priority level assigned to a segment."""
+
     LOW = "Low"
     MEDIUM = "Medium"
     HIGH = "High"
 
 
 class RoadSegment(Base):
+    """Table storing inspection information for individual road segments."""
+
     __tablename__ = "road_segments"
 
+    # Unique identifier for the segment. ``uuid.uuid4`` is used to generate a
+    # random UUID when new rows are inserted.
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Human readable name or location label for the segment.
     name = Column(String, nullable=False)
+
+    # Spatial geometry for the road segment.  For simplicity this is stored as a
+    # WKT string, but could be swapped out for PostGIS types in a real project.
     geometry = Column(String, nullable=False)
+
+    # Condition index produced by an ML model.  Lower values indicate poorer
+    # quality.
     road_condition_index = Column(Integer, nullable=False)
+
+    # List of damage types detected on the segment.
     damage_types = Column(JSON, nullable=False, default=list)
+
+    # Timestamp for the last inspection event.  Defaults to the row creation
+    # time.
     last_inspection = Column(DateTime, default=datetime.utcnow)
+
+    # Derived priority level used for alerting and sorting.
     priority = Column(Enum(Priority), nullable=False, default=Priority.LOW)
+
+    # Current operational state of the segment.
     status = Column(Enum(RoadStatus), nullable=False, default=RoadStatus.ACTIVE)

--- a/examples/road_inspection/api/road_segments.json
+++ b/examples/road_inspection/api/road_segments.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "1",
+    "name": "Segment A",
+    "geometry": "LINESTRING(0 0, 1 1)",
+    "road_condition_index": 45,
+    "damage_types": ["cracks"],
+    "last_inspection": "2024-01-01T00:00:00Z",
+    "priority": "High",
+    "status": "Needs Repair"
+  },
+  {
+    "id": "2",
+    "name": "Segment B",
+    "geometry": "LINESTRING(1 1, 2 2)",
+    "road_condition_index": 80,
+    "damage_types": ["none"],
+    "last_inspection": "2024-01-02T00:00:00Z",
+    "priority": "Low",
+    "status": "Active"
+  }
+]

--- a/examples/road_inspection/api/schemas.py
+++ b/examples/road_inspection/api/schemas.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+from pydantic import BaseModel, Field
+
+from .models import Priority, RoadStatus
+
+
+class RoadSegmentBase(BaseModel):
+    name: str
+    geometry: str
+    road_condition_index: int = Field(ge=0, le=100)
+    damage_types: List[str]
+    last_inspection: Optional[datetime] = None
+    status: Optional[RoadStatus] = RoadStatus.ACTIVE
+
+
+class RoadSegmentCreate(RoadSegmentBase):
+    pass
+
+
+class RoadSegmentUpdate(BaseModel):
+    name: Optional[str] = None
+    geometry: Optional[str] = None
+    road_condition_index: Optional[int] = Field(default=None, ge=0, le=100)
+    damage_types: Optional[List[str]] = None
+    last_inspection: Optional[datetime] = None
+    status: Optional[RoadStatus] = None
+
+
+class RoadSegmentOut(RoadSegmentBase):
+    id: UUID
+    priority: Priority
+    status: RoadStatus
+
+    class Config:
+        orm_mode = True

--- a/examples/road_inspection/api/schemas.py
+++ b/examples/road_inspection/api/schemas.py
@@ -1,3 +1,5 @@
+"""Pydantic schemas for request and response models."""
+
 from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
@@ -7,11 +9,19 @@ from .models import Priority, RoadStatus
 
 
 class RoadSegmentBase(BaseModel):
+    """Shared properties across create and update operations."""
+
+    # Human readable segment name or location label
     name: str
+    # Geometry string (e.g. WKT or GeoJSON)
     geometry: str
+    # ML-derived quality index, enforced between 0 and 100 by Pydantic
     road_condition_index: int = Field(ge=0, le=100)
+    # Types of damage found on the segment
     damage_types: List[str]
+    # Timestamp of the last inspection
     last_inspection: Optional[datetime] = None
+    # Operational status of the segment
     status: Optional[RoadStatus] = RoadStatus.ACTIVE
 
 
@@ -20,6 +30,8 @@ class RoadSegmentCreate(RoadSegmentBase):
 
 
 class RoadSegmentUpdate(BaseModel):
+    """Fields that can be modified for an existing segment."""
+
     name: Optional[str] = None
     geometry: Optional[str] = None
     road_condition_index: Optional[int] = Field(default=None, ge=0, le=100)
@@ -29,6 +41,8 @@ class RoadSegmentUpdate(BaseModel):
 
 
 class RoadSegmentOut(RoadSegmentBase):
+    """Representation used in API responses."""
+
     id: UUID
     priority: Priority
     status: RoadStatus


### PR DESCRIPTION
## Summary
- add road inspection API with CRUD operations for road segments
- integrate PostgreSQL via SQLAlchemy with JSON fallback when DB connection fails
- provide alert endpoint for high priority segments needing repair

## Testing
- `make test` *(fails: ModuleNotFoundError for project dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683f254bd8ac8331a798a5c7d0734733